### PR TITLE
Implement thai time telling quizzes

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,8 +75,21 @@
       </div>
       <a href="numbers-quiz.html" class="start-btn">Start Numbers Quiz</a>
     </div>
-  </div>
-  <script src="quiz.js"></script>
-  <script src="home.js"></script>
-</body>
-</html>
+
+    <div class="quiz-card" onclick="window.location.href='time-quiz.html'">
+      <h2>⏰ Time Quiz</h2>
+      <p>Telling time in Thai: keywords, formats, and common phrases.</p>
+      <div class="features">
+        <ul>
+          <li>✅ Key words (นาที, โมง, ทุ่ม, ครึ่ง, ตรง)</li>
+          <li>✅ AM/PM patterns (ตี…, …โมงเช้า, …ทุ่ม)</li>
+          <li>✅ Practical sentences</li>
+        </ul>
+      </div>
+      <a href="time-quiz.html" class="start-btn">Start Time Quiz</a>
+    </div>
+   </div>
+   <script src="quiz.js"></script>
+   <script src="home.js"></script>
+  </body>
+ </html>

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,13 @@ body.time-quiz #symbol .secondary {
   margin-top: 0.15em;
   font-weight: 600;
 }
+body.time-quiz #symbol .tertiary {
+  display: block;
+  font-size: 0.34em;
+  opacity: 0.92;
+  margin-top: 0.10em;
+  font-weight: 600;
+}
 
 /* Vowel quiz */
 body.vowel-quiz #symbol {

--- a/styles.css
+++ b/styles.css
@@ -353,6 +353,13 @@ body.time-quiz #symbol {
   line-height: 1.2;
 }
 body.time-quiz .options { max-width: 620px; }
+body.time-quiz #symbol .secondary {
+  display: block;
+  font-size: 0.38em;
+  opacity: 0.95;
+  margin-top: 0.15em;
+  font-weight: 600;
+}
 
 /* Vowel quiz */
 body.vowel-quiz #symbol {

--- a/styles.css
+++ b/styles.css
@@ -342,6 +342,18 @@ body.numbers-quiz .options { max-width: 600px; }
 .pro-tip { margin-top: 1.2em; font-size: 0.95em; opacity: 0.95; }
 .pro-tip small { opacity: 0.9; }
 
+/* Time quiz */
+body.time-quiz h1 { margin-bottom: 0.2em; }
+body.time-quiz #symbol {
+  font-size: 4.2em;
+  margin: 0.6em 0 0.6em 0;
+  font-weight: 800;
+  color: white;
+  text-shadow: 3px 3px 6px rgba(0,0,0,0.3);
+  line-height: 1.2;
+}
+body.time-quiz .options { max-width: 620px; }
+
 /* Vowel quiz */
 body.vowel-quiz #symbol {
   font-size: 8em;

--- a/time-quiz.html
+++ b/time-quiz.html
@@ -75,15 +75,14 @@
           const rand = pool[Math.floor(Math.random() * pool.length)];
           if (!choices.find(c => c.phonetic === rand.phonetic)) choices.push(rand);
         }
-        const symbolAriaLabel = `Thai, English and phonetic: ${answer.thai} — ${englishOf(answer)} — ${answer.phonetic}`;
+        const symbolAriaLabel = `Thai and English: ${answer.thai} — ${englishOf(answer)}`;
         return { answer, choices, symbolAriaLabel };
       },
       renderSymbol: (answer, els) => {
         const english = englishOf(answer);
         const thai = answer.thai || '';
-        const phon = answer.phonetic || '';
-        els.symbolEl.innerHTML = `${thai}${english ? `<span class=\"secondary\">${english}</span>` : ''}${phon ? `<span class=\"tertiary\">${phon}</span>` : ''}`;
-        els.symbolEl.setAttribute('aria-label', `Thai, English and phonetic: ${thai}${english ? ' — ' + english : ''}${phon ? ' — ' + phon : ''}`);
+        els.symbolEl.innerHTML = `${thai}${english ? `<span class=\"secondary\">${english}</span>` : ''}`;
+        els.symbolEl.setAttribute('aria-label', `Thai and English: ${thai}${english ? ' — ' + english : ''}`);
       },
       renderButtonContent: (choice) => choice.phonetic,
       ariaLabelForChoice: (choice) => `Answer: ${choice.phonetic}`,

--- a/time-quiz.html
+++ b/time-quiz.html
@@ -75,16 +75,15 @@
           const rand = pool[Math.floor(Math.random() * pool.length)];
           if (!choices.find(c => c.phonetic === rand.phonetic)) choices.push(rand);
         }
-        const symbolAriaLabel = `Thai and English: ${answer.thai} — ${englishOf(answer)}`;
+        const symbolAriaLabel = `Thai, English and phonetic: ${answer.thai} — ${englishOf(answer)} — ${answer.phonetic}`;
         return { answer, choices, symbolAriaLabel };
       },
       renderSymbol: (answer, els) => {
         const english = englishOf(answer);
         const thai = answer.thai || '';
-        els.symbolEl.innerHTML = english
-          ? `${thai}<span class="secondary">${english}</span>`
-          : `${thai}`;
-        els.symbolEl.setAttribute('aria-label', `Thai and English: ${thai}${english ? ' — ' + english : ''}`);
+        const phon = answer.phonetic || '';
+        els.symbolEl.innerHTML = `${thai}${english ? `<span class=\"secondary\">${english}</span>` : ''}${phon ? `<span class=\"tertiary\">${phon}</span>` : ''}`;
+        els.symbolEl.setAttribute('aria-label', `Thai, English and phonetic: ${thai}${english ? ' — ' + english : ''}${phon ? ' — ' + phon : ''}`);
       },
       renderButtonContent: (choice) => choice.phonetic,
       ariaLabelForChoice: (choice) => `Answer: ${choice.phonetic}`,

--- a/time-quiz.html
+++ b/time-quiz.html
@@ -60,6 +60,10 @@
       {"thai":"พักเบรกใช้เวลาสิบนาที","phonetic":"náam-phàk rao khᴐ̌ɔp chái wee-laa sìp naa-thii","translation":"The break takes 10 minutes"}
     ]`);
 
+    function englishOf(item) {
+      return item.english || item.note || item.translation || '';
+    }
+
     const pool = [...keyWords, ...timeFormats, ...examples];
 
     ThaiQuiz.setupQuiz({
@@ -71,9 +75,16 @@
           const rand = pool[Math.floor(Math.random() * pool.length)];
           if (!choices.find(c => c.phonetic === rand.phonetic)) choices.push(rand);
         }
-        const symbolText = `${answer.thai}`;
-        const symbolAriaLabel = `Thai time phrase: ${answer.thai}`;
-        return { answer, choices, symbolText, symbolAriaLabel };
+        const symbolAriaLabel = `Thai and English: ${answer.thai} — ${englishOf(answer)}`;
+        return { answer, choices, symbolAriaLabel };
+      },
+      renderSymbol: (answer, els) => {
+        const english = englishOf(answer);
+        const thai = answer.thai || '';
+        els.symbolEl.innerHTML = english
+          ? `${thai}<span class="secondary">${english}</span>`
+          : `${thai}`;
+        els.symbolEl.setAttribute('aria-label', `Thai and English: ${thai}${english ? ' — ' + english : ''}`);
       },
       renderButtonContent: (choice) => choice.phonetic,
       ariaLabelForChoice: (choice) => `Answer: ${choice.phonetic}`,

--- a/time-quiz.html
+++ b/time-quiz.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Thai Time Quiz</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="time-quiz">
+  <h1>Thai Time Quiz</h1>
+  <div class="subtitle">Choose the correct phonetic for the Thai time phrase</div>
+  <div id="symbol" role="text" aria-label="Thai time phrase">?</div>
+  <div class="options" id="options" role="group" aria-label="Answer options"></div>
+  <div id="feedback" role="status" aria-live="polite"></div>
+  <button id="nextBtn" aria-label="Next question">Next</button>
+  <div class="stats" id="stats"></div>
+  <div class="footer">
+    <a href="index.html" class="back-btn">← Back to Home</a>
+  </div>
+
+  <script src="quiz.js"></script>
+  <script>
+    // Datasets derived from the provided spec
+    const keyWords = JSON.parse(`[
+      {"english":"Hour (o’clock)","thai":"โมง","phonetic":"mooŋ"},
+      {"english":"Hour (o’clock)","thai":"ทุ่ม","phonetic":"thûm"},
+      {"english":"Hour (o’clock)","thai":"นาฬิกา","phonetic":"naa-lí-gaa"},
+      {"english":"Minute","thai":"นาที","phonetic":"naa-thii"},
+      {"english":"Second","thai":"วินาที","phonetic":"wí-naa-thii"},
+      {"english":"Time","thai":"เวลา","phonetic":"wee-laa"},
+      {"english":"O’clock sharp","thai":"ตรง","phonetic":"dtroŋ"},
+      {"english":"Half past (30 min)","thai":"ครึ่ง","phonetic":"khrɯ̂ŋ"},
+      {"english":"Quarter","thai":"หนึ่งในสี่","phonetic":"nɯ̀ŋ nai sìi"},
+      {"english":"Early morning (1–5 AM)","thai":"ตี…","phonetic":"dtii …"},
+      {"english":"Morning (6–11 AM)","thai":"…โมงเช้า","phonetic":"…mooŋ cháo"},
+      {"english":"Noon","thai":"เที่ยง","phonetic":"thîaŋ"},
+      {"english":"Afternoon (1–3 PM)","thai":"บ่าย…โมง","phonetic":"bàay … mooŋ"},
+      {"english":"Late afternoon (4–6 PM)","thai":"…โมงเย็น","phonetic":"…mooŋ yen"},
+      {"english":"Evening/Night (7–11 PM)","thai":"…ทุ่ม","phonetic":"…thûm"},
+      {"english":"Midnight","thai":"เที่ยงคืน","phonetic":"thîaŋ-kʉʉn"}
+    ]`);
+
+    const timeFormats = JSON.parse(`[
+      {"thai":"ตีหนึ่ง","phonetic":"dtii nɯ̀ŋ","note":"1 AM"},
+      {"thai":"หกโมงเช้า","phonetic":"hòk mooŋ cháo","note":"6 AM"},
+      {"thai":"เที่ยง","phonetic":"thîaŋ","note":"12 PM (noon)"},
+      {"thai":"บ่ายโมง","phonetic":"bàay mooŋ","note":"1 PM"},
+      {"thai":"บ่ายสามโมง","phonetic":"bàay săam mooŋ","note":"3 PM"},
+      {"thai":"สี่โมงเย็น","phonetic":"sìi mooŋ yen","note":"4 PM"},
+      {"thai":"สองทุ่ม","phonetic":"sǒn thûm","note":"8 PM"},
+      {"thai":"เที่ยงคืน","phonetic":"thîaŋ-kʉʉn","note":"12 AM (midnight)"}
+    ]`);
+
+    const examples = JSON.parse(`[
+      {"thai":"กี่โมงแล้ว?","phonetic":"gìi mooŋ lɛ́ɛo?","translation":"What time is it now?"},
+      {"thai":"ตอนนี้เป็นสี่โมงเย็น","phonetic":"tîi-níi bpen sìi mooŋ yen","translation":"It’s 4 PM"},
+      {"thai":"ผมตื่นเช้าตีสี่","phonetic":"phǒm tam ŋaan tʉ̀ʉn cháo sìi dtii","translation":"I wake up at 4 AM"},
+      {"thai":"ฉันมาถึงบ้านบ่ายสองโมง","phonetic":"chǎn maa thʉ̌ŋ bâan bàay sɔ̌ɔŋ mooŋ","translation":"I arrived home at 2 PM"},
+      {"thai":"เราจะเจอกันหกโมงเช้าตรง","phonetic":"raw jà jer kan hòk mooŋ cháo dtrooŋ","translation":"Let’s meet at exactly 6 AM"},
+      {"thai":"พักเบรกใช้เวลาสิบนาที","phonetic":"náam-phàk rao khᴐ̌ɔp chái wee-laa sìp naa-thii","translation":"The break takes 10 minutes"}
+    ]`);
+
+    const pool = [...keyWords, ...timeFormats, ...examples];
+
+    ThaiQuiz.setupQuiz({
+      elements: { symbol: 'symbol', options: 'options', feedback: 'feedback', nextBtn: 'nextBtn', stats: 'stats' },
+      pickRound: () => {
+        const answer = pool[Math.floor(Math.random() * pool.length)];
+        const choices = [answer];
+        while (choices.length < 4) {
+          const rand = pool[Math.floor(Math.random() * pool.length)];
+          if (!choices.find(c => c.phonetic === rand.phonetic)) choices.push(rand);
+        }
+        const symbolText = `${answer.thai}`;
+        const symbolAriaLabel = `Thai time phrase: ${answer.thai}`;
+        return { answer, choices, symbolText, symbolAriaLabel };
+      },
+      renderButtonContent: (choice) => choice.phonetic,
+      ariaLabelForChoice: (choice) => `Answer: ${choice.phonetic}`,
+      isCorrect: (choice, answer) => choice.phonetic === answer.phonetic
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Add a new 'Telling Time in Thai' quiz with associated content and navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb062df2-a885-4217-9a95-7cd13f40fe91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb062df2-a885-4217-9a95-7cd13f40fe91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

