### PR TITLE
Remove card from day and month

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -257,14 +257,14 @@ body.home .footer {
 }
 
 .today-card {
-  background: rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(8px);
-  border-radius: 18px;
   display: inline-block;
-  padding: 1em;
+  padding: 0;
   margin: 0 auto 2em;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  box-shadow: 0 10px 25px rgba(0,0,0,0.15);
+  background: transparent;
+  backdrop-filter: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .today-grid {
@@ -313,7 +313,7 @@ body.home .footer {
 @media (max-width: 560px) {
   .today-grid { grid-template-columns: 1fr; gap: 0.6em; }
   .sep { display: none; }
-  .today-card { width: 100%; padding: 0.9em 1em; display: block; }
+  .today-card { width: 100%; padding: 0; display: block; }
 }
 
 /* Consonant quiz */


### PR DESCRIPTION
Remove card styling from Today and Month sections to blend them into the background.

---
<a href="https://cursor.com/background-agent?bcId=bc-32b45bec-145b-4c02-b8ba-a2e1621c405a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32b45bec-145b-4c02-b8ba-a2e1621c405a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

