### PR TITLE
Display Thai translation below number

### DIFF
--- a/numbers-quiz.html
+++ b/numbers-quiz.html
@@ -76,6 +76,12 @@
         const symbolAriaLabel = `Number and Thai: ${answer.number} ${answer.thai}`;
         return { answer, choices, symbolText, symbolAriaLabel };
       },
+      renderSymbol: (answer, els) => {
+        const num = answer.number || '';
+        const thai = answer.thai || '';
+        els.symbolEl.innerHTML = `${num}${thai ? `<span class="secondary">${thai}</span>` : ''}`;
+        els.symbolEl.setAttribute('aria-label', `Number and Thai: ${num}${thai ? ' ' + thai : ''}`);
+      },
       renderButtonContent: (choice) => choice.phonetic,
       ariaLabelForChoice: (choice) => `Answer: ${choice.phonetic}`,
       isCorrect: (choice, answer) => choice.phonetic === answer.phonetic

--- a/styles.css
+++ b/styles.css
@@ -426,6 +426,13 @@ body.numbers-quiz #symbol {
   line-height: 1.2;
 }
 body.numbers-quiz .options { max-width: 600px; }
+body.numbers-quiz #symbol .secondary {
+  display: block;
+  font-size: 0.38em;
+  opacity: 0.95;
+  margin-top: 0.15em;
+  font-weight: 600;
+}
 .pro-tip { margin-top: 1.2em; font-size: 0.95em; opacity: 0.95; }
 .pro-tip small { opacity: 0.9; }
 


### PR DESCRIPTION
Display the Thai number below the numeric one in the number quiz.

---
<a href="https://cursor.com/background-agent?bcId=bc-1aa26c23-7f27-4f39-a500-e0796ee0e645">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1aa26c23-7f27-4f39-a500-e0796ee0e645">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

