### PR TITLE
Investigate quiz data loading failure

### DIFF
--- a/quiz-loader.js
+++ b/quiz-loader.js
@@ -1,6 +1,18 @@
 (function() {
   'use strict';
 
+  function handleDataLoadError(err) {
+    var fb = document.getElementById('feedback');
+    if (fb) {
+      var msg = 'Failed to load data.';
+      if (window.location.protocol === 'file:') {
+        msg += ' Open this site via a local server (e.g., python3 -m http.server) so JSON files can be fetched.';
+      }
+      fb.textContent = msg;
+    }
+    try { console.error('Data load error:', err); } catch (e) {}
+  }
+
   // Centralized quiz configurations
   var ThaiQuizConfigs = {
     consonants: {
@@ -49,7 +61,7 @@
               isCorrect: function(choice, answer) { return choice.name === answer.name; }
             });
           })
-          .catch(function(){ document.getElementById('feedback').textContent = 'Failed to load data.'; });
+          .catch(function(err){ handleDataLoadError(err); });
       }
     },
 
@@ -76,7 +88,7 @@
               isCorrect: function(choice, answer) { return choice.sound === answer.sound; }
             });
           })
-          .catch(function(){ document.getElementById('feedback').textContent = 'Failed to load data.'; });
+          .catch(function(err){ handleDataLoadError(err); });
       }
     },
 
@@ -238,7 +250,7 @@
               isCorrect: function(choice, answer) { return choice.phonetic === answer.phonetic; }
             });
           })
-          .catch(function(){ document.getElementById('feedback').textContent = 'Failed to load data.'; });
+          .catch(function(err){ handleDataLoadError(err); });
       }
     },
 
@@ -284,7 +296,7 @@
             ariaLabelForChoice: function(choice) { return 'Answer: ' + choice.phonetic; },
             isCorrect: function(choice, answer) { return choice.phonetic === answer.phonetic; }
           });
-        }).catch(function(){ document.getElementById('feedback').textContent = 'Failed to load data.'; });
+        }).catch(function(err){ handleDataLoadError(err); });
       }
     },
 
@@ -348,7 +360,7 @@
               } catch (e) {}
             }
           });
-        }).catch(function(){ document.getElementById('feedback').textContent = 'Failed to load data.'; });
+        }).catch(function(err){ handleDataLoadError(err); });
       }
     }
   };


### PR DESCRIPTION
Improve data load error messages and diagnostics, especially for `file://` protocol issues, to resolve "Failed to load data" errors.

The "Failed to load data" error occurred because quizzes attempted to fetch JSON data files, but browsers block `file://` protocol pages from making `file://` XHR requests for security reasons. The color quiz worked as its data was inline. This PR adds a specific hint for `file://` users and logs the actual fetch error to the console for better debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9a4246a-218c-402a-9b0c-adc313fbcf2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9a4246a-218c-402a-9b0c-adc313fbcf2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

