### PR TITLE
Add shadow to white color text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -423,7 +423,7 @@ body.color-quiz #symbol {
   margin: 0.6em 0 0.6em 0;
   font-weight: 800;
   color: #111111;
-  text-shadow: none;
+  text-shadow: 0 1px 1px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.45);
   line-height: 1.2;
 }
 body.color-quiz .options { max-width: 500px; }


### PR DESCRIPTION
Add a text shadow to the color quiz symbol to ensure white and light-colored text is visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-e713d66b-252c-4e46-ae5b-1ce935567b76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e713d66b-252c-4e46-ae5b-1ce935567b76">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

