### PR TITLE
Adjust header title font size for better hierarchy

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,7 @@ h1 {
   margin: 0;
   color: #111111;
   font-weight: 800;
-  font-size: clamp(1.2em, 3.4vw, 1.8em);
+  font-size: clamp(1.9em, 3.8vw, 2.4em);
   letter-spacing: 0.2px;
   text-shadow: none;
 }
@@ -67,7 +67,7 @@ h1 {
   font-size: clamp(0.9em, 2vw, 1.05em);
   opacity: 0.9;
 }
-body.home .app-bar .brand-title { margin: 0; font-size: clamp(1.2em, 3.4vw, 1.8em); }
+body.home .app-bar .brand-title { margin: 0; font-size: clamp(1.9em, 3.8vw, 2.4em); }
 body.home .app-bar .brand-subtitle { margin: 0; }
 
 .app-header .today-card {


### PR DESCRIPTION
Increase header title font size to ensure it is larger than quiz names.

Previously, the header title was smaller or similar in size to the quiz names, which was counter-intuitive. This change makes the title visually more prominent.

---
<a href="https://cursor.com/background-agent?bcId=bc-e982ddbe-ceec-49a5-8933-6267af28d370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e982ddbe-ceec-49a5-8933-6267af28d370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

