### PR TITLE
Fix social box cropping on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -310,6 +310,7 @@ body.home .socials-card {
   width: 100%;
   margin: 1.5em auto 0;
   border: 1px solid rgba(0, 0, 0, 0.08);
+  box-sizing: border-box;
   transition: all 0.2s ease;
 }
 body.home .socials-card h2 {


### PR DESCRIPTION
Add `box-sizing: border-box` to `.socials-card` to fix right-side cropping on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-acd3f70f-0c4e-4c6f-8908-c46e312a1303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acd3f70f-0c4e-4c6f-8908-c46e312a1303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

