### PR TITLE
Remove social box outline for background blending

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -302,14 +302,14 @@ body.home .footer {
 
 /* Socials card */
 body.home .socials-card {
-  background: #ffffff;
+  background: transparent;
   backdrop-filter: none;
   border-radius: 16px;
   padding: 1em 1.2em;
   max-width: 760px;
   width: 100%;
   margin: 1.5em auto 0;
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: none;
   transition: all 0.2s ease;
 }
 body.home .socials-card h2 {


### PR DESCRIPTION
Remove border and background from the social box to blend it with the page.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6c45834-520c-4d2e-b853-2f5ba188a0c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6c45834-520c-4d2e-b853-2f5ba188a0c6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

