### PR TITLE
Center social footer on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -311,6 +311,11 @@ body.home .socials-card {
   margin: 1.5em auto 0;
   border: none;
   transition: all 0.2s ease;
+  /* Ensure consistent centering across mobile Safari */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 body.home .socials-card h2 {
   margin: 0 0 0.6em 0;
@@ -335,9 +340,14 @@ body.home .socials-card .links {
   gap: 0.5em;
   flex-wrap: wrap;
   justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 body.home .socials-card a.chip {
   text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 body.home .socials-card a.chip:link,
 body.home .socials-card a.chip:visited {


### PR DESCRIPTION
Center the social footer on mobile devices, specifically addressing alignment issues on iPhone Safari.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f0bbe44-ab72-4724-9c5e-b99294fc699d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f0bbe44-ab72-4724-9c5e-b99294fc699d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

