### PR TITLE
Show quiz loading indicator

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -9,7 +9,7 @@
 <body class="quiz-page">
   <h1 id="page-title">Thai Quiz</h1>
   <div class="subtitle" id="page-subtitle"></div>
-  <div id="symbol" role="text" aria-label="Quiz prompt">?</div>
+  <div id="symbol" role="text" aria-label="Quiz prompt"><span class="loading"><span class="spinner" aria-hidden="true"></span> Loading...</span></div>
   <div class="options" id="options" role="group" aria-label="Answer options"></div>
   <div id="feedback" role="status" aria-live="polite"></div>
   <button id="nextBtn" aria-label="Next question">Next</button>

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,29 @@ body {
   color: #111111;
 }
 
+/* Lightweight loader */
+.loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid rgba(0,0,0,0.15);
+  border-top-color: #00247D;
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 h1 {
   color: #111111;
   text-shadow: none;


### PR DESCRIPTION
Replaced the initial '?' placeholder with a loading spinner to improve user experience during quiz data loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3e3cb5a-5756-42c0-9924-d9488cde8c10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3e3cb5a-5756-42c0-9924-d9488cde8c10">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

