### PR TITLE
Implement thai tense markers quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Hosted with GitHub Pages: [https://jdelaire.github.io/learn-thai-quiz](https://j
 - **Jobs**: Common jobs and occupations with Thai script and phonetics
 - **Foods**: Common Thai foods, fruits, and cooking methods with phonetics and example phrases
 - **Months & Seasons**: 12 months and Thailand’s seasons with Thai script, phonetics, and example sentences
+- **Tense Markers**: Thai time words and structures; examples after correct answers
 
 ### Quick start (local)
 
@@ -110,6 +111,7 @@ Tip: if your quiz shows an example sentence on correct answers, you can loop thr
 - `data/*.json`: Quiz datasets and metadata
 - `data/emoji-rules/*.json`: Optional per-quiz emoji matcher rules (pattern → emoji)
   - Datasets may optionally include an `id` per item; when present, examples prefer `id` for lookups (falling back to `english`).
+  - For Tense Markers, see `data/tenses.json`, `data/tenses-examples.json`, and optional `data/emoji-rules/tenses.json`
 - `profile.jpg`: Avatar shown in the home page Socials card
 
 ### How it works
@@ -144,6 +146,11 @@ Use this checklist and templates to add a quiz end‑to‑end with minimal chang
 Basic item (English/Thai/phonetic):
 ```json
 { "english": "water", "thai": "น้ำ", "phonetic": "náam" }
+```
+
+Tense marker item:
+```json
+{ "english": "already", "thai": "แล้ว", "phonetic": "lɛ́ɛw" }
 ```
 
 Numbers:
@@ -250,7 +257,7 @@ Utilities you can use: `Utils.fetchJSON(s)`, `Utils.fetchJSONCached(s)`, `Utils.
 #### Emoji rules (data-driven)
 
 - Add a file like `data/emoji-rules/foods.json` with an ordered list of objects `{ "pattern": "regex", "emoji": "🧪" }`.
-- Quizzes that support emojis (foods/rooms/jobs/verbs/classifiers) will load these rules and match against the English text to show the emoji above the symbol.
+- Quizzes that support emojis (foods/rooms/jobs/verbs/classifiers/tenses) will load these rules and match against the English text to show the emoji above the symbol.
 - If the file is missing or empty, the quiz still works (no emoji shown).
 
 #### Homepage card entry (`data/quizzes.json`)
@@ -325,3 +332,39 @@ MIT License © 2025 jdelaire. See the [MIT License](https://opensource.org/licen
 ### Credits
 
 - Data and phonetics curated for learning purposes. Emojis and color accents are used to aid memorization.
+
+### ⏱️ Thai Tense Markers (Time Words & Structures)
+
+Thai uses time markers rather than verb conjugation for tense.
+Structure: [Subject] + [Time Marker] + [Verb] + [Particle]
+
+| English | Thai Word | Phonetic |
+| --- | --- | --- |
+| now / currently | ตอนนี้ | dtɔɔn-níi |
+| today | วันนี้ | wan-níi |
+| yesterday | เมื่อวาน | mûea-waan |
+| tomorrow | พรุ่งนี้ | phrûŋ-níi |
+| already | แล้ว | lɛ́ɛw |
+| not yet | ยังไม่ | yaŋ mâi |
+| still | ยัง | yaŋ |
+| just (recently) | เพิ่ง | phə̂ŋ |
+| soon | เร็วๆนี้ | rew-rew níi |
+| in the past | เมื่อก่อน | mûea-gɔ̀ɔn |
+| in the future | ในอนาคต | nai à-naa-khót |
+| often | บ่อยๆ | bɔ̀y-bɔ̀y |
+| sometimes | บางที | baaŋ-thii |
+| always | เสมอ | sà-mɯ̌ɯ |
+| never | ไม่เคย | mâi khəəy |
+| ever | เคย | khəəy |
+| still not (yet) | ยังไม่ได้ | yaŋ mâi dâay |
+| cannot yet | ยังทำไม่ได้ | yaŋ tham mâi dâay |
+
+🧠 Tense Examples
+
+- phǒm rian phaa-sǎa thai lɛ́ɛw → I have already studied Thai
+- khun gin khâaw rʉ́ yaŋ? → Have you eaten yet?
+- chǎn yang mâi bpai raan-khǎay → I haven’t gone to the shop yet
+- phǒm jà bpai cháw níi → I will go this morning
+- kháw phə̂ŋ maa → He just arrived
+- wan-níi mâi mii rian → There’s no class today
+- phǒm mâi khəəy gin néua → I never eat beef

--- a/data/emoji-rules/tenses.json
+++ b/data/emoji-rules/tenses.json
@@ -1,0 +1,10 @@
+[
+  { "pattern": "now|currently|today|this (morning|afternoon|evening)?", "emoji": "🕒" },
+  { "pattern": "yesterday|in the past|before", "emoji": "📅" },
+  { "pattern": "tomorrow|soon|in the future|later", "emoji": "🚀" },
+  { "pattern": "already|ever", "emoji": "✅" },
+  { "pattern": "not yet|still not|cannot yet", "emoji": "⏳" },
+  { "pattern": "still", "emoji": "🔁" },
+  { "pattern": "just", "emoji": "✨" },
+  { "pattern": "often|sometimes|always|never", "emoji": "🔄" }
+]

--- a/data/quizzes.json
+++ b/data/quizzes.json
@@ -102,8 +102,15 @@
     "description": "Practice Thai job and occupation vocabulary with phonetics.",
     "bullets": ["Common professions","Thai script + phonetics","Emoji hints"],
     "categories": ["Vocabulary","Beginner"]
-  }
-  ,
+  },
+  {
+    "id": "tenses",
+    "title": "⏱️ Thai Tense Markers",
+    "href": "quiz.html?quiz=tenses",
+    "description": "Practice Thai time markers and aspects: now, already, not yet, soon, often, never.",
+    "bullets": ["Time words & structures","English/Thai/phonetics","Examples after correct answers"],
+    "categories": ["Phrases","Beginner"]
+  },
   {
     "id": "foods",
     "title": "🍛 Common Thai Foods",

--- a/data/tenses-examples.json
+++ b/data/tenses-examples.json
@@ -1,0 +1,9 @@
+{
+  "already": "I have already studied Thai → phǒm rian phaa-sǎa thai lɛ́ɛw",
+  "not yet": "Have you eaten yet? → khun gin khâaw rʉ́ yaŋ?",
+  "still not (yet)": "I haven’t gone to the shop yet → chǎn yang mâi bpai raan-khǎay",
+  "tomorrow": "I will go this morning → phǒm jà bpai cháw níi",
+  "just (recently)": "He just arrived → kháw phə̂ŋ maa",
+  "today": "There’s no class today → wan-níi mâi mii rian",
+  "never": "I never eat beef → phǒm mâi khəəy gin néua"
+}

--- a/data/tenses.json
+++ b/data/tenses.json
@@ -1,0 +1,20 @@
+[
+  { "english": "now / currently", "thai": "ตอนนี้", "phonetic": "dtɔɔn-níi" },
+  { "english": "today", "thai": "วันนี้", "phonetic": "wan-níi" },
+  { "english": "yesterday", "thai": "เมื่อวาน", "phonetic": "mûea-waan" },
+  { "english": "tomorrow", "thai": "พรุ่งนี้", "phonetic": "phrûŋ-níi" },
+  { "english": "already", "thai": "แล้ว", "phonetic": "lɛ́ɛw" },
+  { "english": "not yet", "thai": "ยังไม่", "phonetic": "yaŋ mâi" },
+  { "english": "still", "thai": "ยัง", "phonetic": "yaŋ" },
+  { "english": "just (recently)", "thai": "เพิ่ง", "phonetic": "phə̂ŋ" },
+  { "english": "soon", "thai": "เร็วๆนี้", "phonetic": "rew-rew níi" },
+  { "english": "in the past", "thai": "เมื่อก่อน", "phonetic": "mûea-gɔ̀ɔn" },
+  { "english": "in the future", "thai": "ในอนาคต", "phonetic": "nai à-naa-khót" },
+  { "english": "often", "thai": "บ่อยๆ", "phonetic": "bɔ̀y-bɔ̀y" },
+  { "english": "sometimes", "thai": "บางที", "phonetic": "baaŋ-thii" },
+  { "english": "always", "thai": "เสมอ", "phonetic": "sà-mɯ̌ɯ" },
+  { "english": "never", "thai": "ไม่เคย", "phonetic": "mâi khəəy" },
+  { "english": "ever", "thai": "เคย", "phonetic": "khəəy" },
+  { "english": "still not (yet)", "thai": "ยังไม่ได้", "phonetic": "yaŋ mâi dâay" },
+  { "english": "cannot yet", "thai": "ยังทำไม่ได้", "phonetic": "yaŋ tham mâi dâay" }
+]

--- a/quiz-loader.js
+++ b/quiz-loader.js
@@ -497,6 +497,49 @@
           })));
         }).catch(function(err){ handleDataLoadError(err); });
       }
+    },
+
+    tenses: {
+      title: '⏱️ Thai Tense Markers',
+      subtitle: 'Choose the correct phonetic for the Thai time marker',
+      bodyClass: 'questions-quiz',
+      init: function() {
+        try {
+          var footer = document.querySelector('.footer');
+          if (footer) {
+            var tip = document.createElement('div');
+            tip.className = 'pro-tip';
+            tip.innerHTML = '<small>Structure: <strong>[Subject] + [Time Marker] + [Verb] + [Particle]</strong></small>';
+            footer.appendChild(tip);
+          }
+        } catch (e) {}
+
+        var emojiForTense = (function(){
+          var matcher = null;
+          return function(item){
+            try { return matcher ? matcher(String(item && item.english || '')) : ''; } catch (e) { return ''; }
+          };
+        })();
+
+        Utils.fetchJSONs([
+          'data/emoji-rules/tenses.json',
+          'data/tenses.json',
+          'data/tenses-examples.json'
+        ]).then(function(results){
+          var rules = results[0] || [];
+          var matcher = Utils.buildEmojiMatcher(rules);
+          emojiForTense = function(item){ try { return matcher(String(item && item.english || '')); } catch (e) { return ''; } };
+          var data = results[1] || [];
+          var examples = results[2] || {};
+          ThaiQuiz.setupQuiz(Object.assign({ elements: defaultElements }, Utils.createStandardQuiz({
+            data: data,
+            examples: examples,
+            answerKey: 'phonetic',
+            labelPrefix: 'English and Thai: ',
+            buildSymbol: function(a){ return { english: a.english || '', thai: a.thai || '', emoji: emojiForTense(a) }; }
+          })));
+        }).catch(function(err){ handleDataLoadError(err); });
+      }
     }
   };
 


### PR DESCRIPTION
Add the 'Thai Tense Markers' quiz to provide a new learning module for Thai time words and structures.

The quiz follows the 'Thai Questions Quiz' style, featuring English/Thai/phonetic questions, examples after correct answers, and emoji hints.

---
<a href="https://cursor.com/background-agent?bcId=bc-c115a323-14ec-446b-9845-e42b6334e19b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c115a323-14ec-446b-9845-e42b6334e19b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

