### PR TITLE
Disable incorrect quiz choices after correct answer

### DIFF
--- a/quiz.js
+++ b/quiz.js
@@ -106,6 +106,19 @@
             btn.addEventListener('animationend', function handle() {
               btn.classList.remove('answer-correct');
             }, { once: true });
+            // Disable other options until next question
+            try {
+              const buttons = optionsEl.querySelectorAll('button');
+              buttons.forEach(function(b) {
+                if (b !== btn) {
+                  b.disabled = true;
+                  try { b.setAttribute('aria-disabled', 'true'); } catch (e) {}
+                  try { b.tabIndex = -1; } catch (e) {}
+                }
+              });
+            } catch (e) {}
+            // Also prevent re-clicks on the correct button during the delay
+            try { btn.onclick = null; } catch (e) {}
             // Don't show next button - auto-advance only
             nextBtn.style.display = 'none';
 
@@ -142,7 +155,7 @@
         if (/^[1-9]$/.test(e.key)) {
           const buttons = optionsEl.querySelectorAll('button');
           const index = parseInt(e.key, 10) - 1;
-          if (buttons[index]) {
+          if (buttons[index] && !buttons[index].disabled) {
             buttons[index].click();
           }
         }


### PR DESCRIPTION
Disable other quiz choices after a correct answer and prevent re-clicks on the correct button during auto-advance.

---
<a href="https://cursor.com/background-agent?bcId=bc-de29d2fb-c89b-4885-a4fe-76cb08b8b7bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de29d2fb-c89b-4885-a4fe-76cb08b8b7bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

