### PR TITLE
Continue critical refactoring, maintain readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ Utilities you can use: `Utils.fetchJSONCached(s)`, `Utils.fetchJSONs([urls])`, `
 - `Utils.renderVowelSymbol(symbolEl, symbol)`
   - Render vowel symbols with the shaping‑safe placeholder behavior (ko kai replacement) and set `aria-label`.
 
+#### Utility behavior notes
+- `Utils.pickUniqueChoices(pool, count, keyFn, seed)` returns unique choices by key without infinite loops. It includes `seed` when provided and may return fewer than `count` if the pool lacks enough unique items.
+- `Utils.fetchJSONCached(url)` throws on non‑OK HTTP responses and caches successful fetches. Handle errors via `.catch(...)` or via `handleDataLoadError(...)` in `quiz-loader.js`.
+- `ThaiQuiz.setupQuiz` → `renderButtonContent(choice, state)` can return text or small HTML. If HTML tags are present, the engine assigns `innerHTML` to the button. Only return HTML from trusted content (datasets are static).
+
 #### Emoji rules (data-driven)
 
 - Add a file like `data/emoji-rules/foods.json` with an ordered list of objects `{ "pattern": "regex", "emoji": "🧪" }`.


### PR DESCRIPTION
Refactor `Utils.fetchJSON` to throw on non-OK responses and `Utils.pickUniqueChoices` for robust unique item selection, with corresponding `README.md` updates.

The previous `Utils.pickUniqueChoices` could enter an infinite loop if `keyFn` failed or if the pool contained insufficient unique items to satisfy the requested count. The refactor addresses this by building a unique-by-key pool and performing a random sample without replacement, ensuring termination and correct behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b11fd82-dddf-4b41-98db-12d198aa6fc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b11fd82-dddf-4b41-98db-12d198aa6fc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

