### PR TITLE
Update quiz difficulty and readme

### DIFF
--- a/js/quiz-loader.js
+++ b/js/quiz-loader.js
@@ -47,7 +47,9 @@
               let currentChoices = 4;
               if (state && state.correctAnswers !== undefined) {
                 const correctCount = state.correctAnswers;
-                if (correctCount >= 40) currentChoices = 6;
+                if (correctCount >= 80) currentChoices = 8;
+                else if (correctCount >= 60) currentChoices = 7;
+                else if (correctCount >= 40) currentChoices = 6;
                 else if (correctCount >= 20) currentChoices = 5;
               }
               
@@ -85,7 +87,9 @@
               let currentChoices = 4;
               if (state && state.correctAnswers !== undefined) {
                 const correctCount = state.correctAnswers;
-                if (correctCount >= 40) currentChoices = 6;
+                if (correctCount >= 80) currentChoices = 8;
+                else if (correctCount >= 60) currentChoices = 7;
+                else if (correctCount >= 40) currentChoices = 6;
                 else if (correctCount >= 20) currentChoices = 5;
               }
               
@@ -127,7 +131,9 @@
               let currentChoices = 4;
               if (state && state.correctAnswers !== undefined) {
                 const correctCount = state.correctAnswers;
-                if (correctCount >= 40) currentChoices = 6;
+                if (correctCount >= 80) currentChoices = 8;
+                else if (correctCount >= 60) currentChoices = 7;
+                else if (correctCount >= 40) currentChoices = 6;
                 else if (correctCount >= 20) currentChoices = 5;
               }
               
@@ -175,7 +181,9 @@
         progressiveDifficulty: {
           choicesThresholds: [
             { correctAnswers: 20, choices: 5 },
-            { correctAnswers: 40, choices: 6 }
+            { correctAnswers: 40, choices: 6 },
+            { correctAnswers: 60, choices: 7 },
+            { correctAnswers: 80, choices: 8 }
           ]
         }
       };
@@ -262,7 +270,9 @@
         progressiveDifficulty: {
           choicesThresholds: [
             { correctAnswers: 20, choices: 5 },
-            { correctAnswers: 40, choices: 6 }
+            { correctAnswers: 40, choices: 6 },
+            { correctAnswers: 60, choices: 7 },
+            { correctAnswers: 80, choices: 8 }
           ],
           hideEmojiThreshold: 50
         }
@@ -394,7 +404,7 @@
                 return;
               }
               try {
-                ThaiQuiz.setupQuiz(Object.assign({ elements: defaultElements, quizId: quizId }, Utils.createStandardQuiz({
+                ThaiQuiz.setupQuiz(Object.assign({ elements: defaultElements, quizId: quizId }, Utils.createQuizWithProgressiveDifficulty({
                   data: data
                 })));
               } catch (e) { handleDataLoadError(e); }

--- a/js/utils.js
+++ b/js/utils.js
@@ -188,7 +188,9 @@
   const DEFAULT_PROGRESSIVE_DIFFICULTY = {
     choicesThresholds: [
       { correctAnswers: 20, choices: 5 },
-      { correctAnswers: 40, choices: 6 }
+      { correctAnswers: 40, choices: 6 },
+      { correctAnswers: 60, choices: 7 },
+      { correctAnswers: 80, choices: 8 }
     ]
   };
 


### PR DESCRIPTION
Implement new progressive difficulty thresholds to increase choice options at higher correct answer counts, making this the new default for all quizzes.

The new progression provides 5 choices at 20 correct answers, 6 at 40, 7 at 60, and 8 at 80, applied consistently across manual quiz builders and the global progressive difficulty configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b0d0b9f-1126-484d-8b5d-e4e0343c3a95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b0d0b9f-1126-484d-8b5d-e4e0343c3a95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

