### PR TITLE
Integrate today's date phonetics into player card

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -738,6 +738,38 @@ body.home .socials a.chip {
   color: var(--color-text);
 }
 
+.player-today {
+  margin-top: 0.8em;
+  background: #fafafa;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  padding: 0.6em 0.7em;
+}
+
+.pt-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 0.6em;
+}
+
+.pt-col { min-width: 0; }
+.pt-sep {
+  width: 1px;
+  height: 28px;
+  background: rgba(0,0,0,0.1);
+}
+.pt-thai {
+  font-size: clamp(1em, 3vw, 1.25em);
+  font-weight: 800;
+  color: var(--color-text);
+  line-height: 1.2;
+}
+.pt-phonetic {
+  font-size: clamp(0.75em, 2vw, 0.9em);
+  opacity: 0.9;
+}
+
 @media (max-width: 560px) {
   .player-card { 
     padding: 0.9em 1em; 
@@ -770,6 +802,10 @@ body.home .socials a.chip {
   .xp-value {
     font-size: 0.9em;
   }
+
+  .player-today { padding: 0.55em 0.6em; }
+  .pt-grid { grid-template-columns: 1fr; gap: 0.4em; }
+  .pt-sep { display: none; }
 }
 
 /* Consonant quiz */

--- a/index.html
+++ b/index.html
@@ -77,6 +77,19 @@
           <div class="xp-fill" style="width:0%"></div>
         </div>
       </div>
+      <div class="player-today" aria-label="Today in Thai">
+        <div class="pt-grid">
+          <div class="pt-col" aria-label="Day">
+            <div class="pt-thai" id="player-weekday-thai">...</div>
+            <div class="pt-phonetic" id="player-weekday-phonetic">...</div>
+          </div>
+          <div class="pt-sep" role="separator" aria-orientation="vertical"></div>
+          <div class="pt-col" aria-label="Month">
+            <div class="pt-thai" id="player-month-thai">...</div>
+            <div class="pt-phonetic" id="player-month-phonetic">...</div>
+          </div>
+        </div>
+      </div>
       <div class="player-metrics" role="group" aria-label="Player stats">
         <div class="metric">
           <div class="metric-label">Avg accuracy</div>

--- a/js/home.js
+++ b/js/home.js
@@ -405,6 +405,21 @@
       monthThaiEl.textContent = thaiMonths[month];
       monthPhonEl.textContent = phoneticMonths[month];
     }
+
+    // Populate discreet today info inside player card (no accent colors)
+    const pWeekThaiEl = document.getElementById('player-weekday-thai');
+    const pWeekPhonEl = document.getElementById('player-weekday-phonetic');
+    if (pWeekThaiEl && pWeekPhonEl) {
+      pWeekThaiEl.textContent = thaiWeekdays[day];
+      pWeekPhonEl.textContent = phoneticWeekdays[day];
+    }
+
+    const pMonthThaiEl = document.getElementById('player-month-thai');
+    const pMonthPhonEl = document.getElementById('player-month-phonetic');
+    if (pMonthThaiEl && pMonthPhonEl) {
+      pMonthThaiEl.textContent = thaiMonths[month];
+      pMonthPhonEl.textContent = phoneticMonths[month];
+    }
   } catch (e) { Utils.logError(e, 'home.js: today/month widgets'); }
 
   try {


### PR DESCRIPTION
Add a discreet 'today' section to the player card, showing the current weekday and month in Thai and phonetic script, without inheriting the Today card's styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bc570e5-5e6f-4433-ab43-e7df580faab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bc570e5-5e6f-4433-ab43-e7df580faab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

