### PR TITLE
Thai vowel form quiz generator

### DIFF
--- a/js/builders/index.js
+++ b/js/builders/index.js
@@ -204,7 +204,14 @@
     'vowel-changes': makeStandardQuizBuilder(['data/vowel-changes.json','data/vowel-changes-examples.json'], function(results) {
       const data = results[0] || [];
       const examples = results[1] || {};
-      return { data: data, examples: examples, exampleKey: function(a){ return a.english || a.thai; }, buildSymbol: function(a){ return { english: a.english || '', thai: a.thai || '', emoji: (a && a.emoji) || '' }; } };
+      // Use Thai forms as the answer choices and hide Thai in the prompt
+      return {
+        data: data,
+        examples: examples,
+        answerKey: 'thai',
+        exampleKey: function(a){ return a.english || a.thai; },
+        buildSymbol: function(a){ return { english: a.english || '', thai: '', emoji: (a && a.emoji) || '' }; }
+      };
     })
   };
 


### PR DESCRIPTION
Update 'vowel-changes' quiz to use Thai forms as answers and remove the Thai prompt to prevent answer revelation.

The user requested that the "vowel-changes" quiz present the different Thai forms as answer choices instead of phonetics. Additionally, the Thai version displayed below the question was removed as it directly provided the correct answer, making the quiz too easy.

---
<a href="https://cursor.com/background-agent?bcId=bc-57be4e23-c073-4cd6-80e4-3627f79d0032">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57be4e23-c073-4cd6-80e4-3627f79d0032">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

