### PR TITLE
Remove redundant emojis from vowel quiz

### DIFF
--- a/js/builders/index.js
+++ b/js/builders/index.js
@@ -210,7 +210,7 @@
         examples: examples,
         answerKey: 'thai',
         exampleKey: function(a){ return a.english || a.thai; },
-        buildSymbol: function(a){ return { english: a.english || '', thai: '', emoji: (a && a.emoji) || '' }; }
+        buildSymbol: function(a){ return { english: a.english || '', thai: '', emoji: '' }; }
       };
     })
   };


### PR DESCRIPTION
Remove the emoji from the 'vowel-changes' quiz question prompt because they are all the same and redundant.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c3a1a9c-6e2e-4afe-abe5-7d55b359f8bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9c3a1a9c-6e2e-4afe-abe5-7d55b359f8bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

