### PR TITLE
Add latest quiz resume link to player card

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -749,6 +749,37 @@ body.home .socials a.chip {
   text-align: center;
 }
 
+.player-resume {
+  margin-top: 0.6em;
+  background: #fafafa;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  padding: 0.6em 0.7em;
+  text-align: center;
+}
+.player-resume .resume-label {
+  font-size: 0.72em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.85;
+  margin-bottom: 0.2em;
+  font-weight: 700;
+}
+.player-resume .resume-link {
+  display: inline-block;
+  margin: 0.1em 0;
+  font-weight: 800;
+  color: var(--color-brand);
+  text-decoration: none;
+}
+.player-resume .resume-link:hover {
+  color: var(--color-accent);
+}
+.player-resume .resume-sub {
+  font-size: 0.85em;
+  opacity: 0.9;
+}
+
 .pt-line {
   display: block;
   white-space: nowrap;

--- a/js/utils-agg.js
+++ b/js/utils-agg.js
@@ -85,6 +85,9 @@
     getPlayerAvatar: player.getPlayerAvatar,
     formatNumber: player.formatNumber,
     getXPProgressPercentage: player.getXPProgressPercentage
+    ,
+    // latest attempt
+    getLatestAttempt: player.getLatestAttempt
   };
 })(window);
 


### PR DESCRIPTION
Add a "Resume your quiz" quick link to the player card to allow users to quickly return to their latest attempted quiz.

---
<a href="https://cursor.com/background-agent?bcId=bc-429c85e8-d646-432c-ba2e-ac16afe18743">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-429c85e8-d646-432c-ba2e-ac16afe18743">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

