### PR TITLE
Style example label like back button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -357,12 +357,12 @@ body.quiz-page .stats {
   display: inline-block;
   opacity: 0.95;
   font-size: clamp(0.9em, 1.8vw, 1em);
-  padding: 0.2em 0.6em;
+  padding: 0;
   margin-right: 0.6em;
-  border-radius: 25px;
-  background: var(--color-bg);
+  border-radius: 0;
+  background: transparent;
   color: var(--color-brand);
-  border: 1px solid rgba(0, 36, 125, 0.35);
+  border: none;
   font-weight: 600;
 }
 
@@ -388,12 +388,12 @@ body.quiz-page .stats {
   display: inline-block;
   opacity: 0.95;
   font-size: 0.9em;
-  padding: 0.1em 0.45em;
+  padding: 0;
   margin-right: 0.45em;
-  border-radius: 25px;
-  background: var(--color-bg);
+  border-radius: 0;
+  background: transparent;
   color: var(--color-brand);
-  border: 1px solid rgba(0, 36, 125, 0.35);
+  border: none;
   font-weight: 600;
 }
 


### PR DESCRIPTION
Update example label styles to match the back button's appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-b96273b0-1a33-482b-8b97-ceeff530c99c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b96273b0-1a33-482b-8b97-ceeff530c99c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

