### PR TITLE
Add larger correct message to overlay

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -353,6 +353,14 @@ body.quiz-page .stats {
   animation: cardPopIn 200ms ease forwards;
 }
 
+.example-overlay .overlay-card .heading {
+  display: block;
+  font-weight: 800;
+  font-size: clamp(1.1em, 2.4vw, 1.35em);
+  margin: 0 0 0.2em 0;
+  color: var(--color-brand);
+}
+
 .example-overlay .overlay-card .label {
   display: inline-block;
   opacity: 0.95;

--- a/js/ui/renderers.js
+++ b/js/ui/renderers.js
@@ -51,16 +51,21 @@
       if (!exampleText) return;
 
       var exampleLabel = (global.Utils && global.Utils.i18n && global.Utils.i18n.exampleLabel) || 'Example';
+      var correctHeading = (global.Utils && global.Utils.i18n && global.Utils.i18n.correctHeading) || 'Correct!';
 
       // Build a full-screen overlay to showcase the example prominently
       var overlay = document.createElement('div');
       overlay.className = 'example-overlay';
       try { overlay.setAttribute('role', 'dialog'); } catch (_) {}
       try { overlay.setAttribute('aria-modal', 'true'); } catch (_) {}
-      try { overlay.setAttribute('aria-label', exampleLabel); } catch (_) {}
+      try { overlay.setAttribute('aria-label', correctHeading + ' — ' + exampleLabel); } catch (_) {}
 
       var card = document.createElement('div');
       card.className = 'overlay-card';
+
+      var heading = document.createElement('div');
+      heading.className = 'heading';
+      heading.textContent = correctHeading;
 
       var label = document.createElement('span');
       label.className = 'label';
@@ -70,6 +75,7 @@
       text.className = 'text';
       text.textContent = String(exampleText);
 
+      card.appendChild(heading);
       card.appendChild(label);
       card.appendChild(text);
       overlay.appendChild(card);

--- a/js/util/common.js
+++ b/js/util/common.js
@@ -22,6 +22,7 @@
   const i18n = {
     answerPrefix: 'Answer: ',
     exampleLabel: 'Example',
+    correctHeading: 'Correct!',
     labelEnglishThaiPrefix: 'English and Thai: ',
     labelNumberThaiPrefix: 'Number and Thai: ',
     labelClassMarkerLengthPrefix: 'Class + Marker + Length: ',


### PR DESCRIPTION
Add a prominent "Correct!" heading to the example overlay to provide clear feedback for correct answers.

---
<a href="https://cursor.com/background-agent?bcId=bc-96f082e5-30f9-4913-a7f8-a258fe3f7d39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96f082e5-30f9-4913-a7f8-a258fe3f7d39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

