### PR TITLE
Animate success without example

### DIFF
--- a/js/quiz/factories.js
+++ b/js/quiz/factories.js
@@ -56,14 +56,16 @@
       ariaLabelForChoice: function(choice){ return common.i18n.answerPrefix + (choice && choice[answerKey]); },
       isCorrect: function(choice, answer){ return (choice && choice[answerKey]) === (answer && answer[answerKey]); },
       onAnswered: function(ctx){
-        if (!examples) return;
         const correct = ctx && ctx.correct;
         if (!correct) return;
         try {
           const fb = document.getElementById('feedback');
-          const ans = ctx && ctx.answer || {};
-          const key = (typeof exampleKeyFn === 'function') ? exampleKeyFn(ans) : (ans && ans.english);
-          const ex = examples[key];
+          var ex = null;
+          if (examples) {
+            const ans = ctx && ctx.answer || {};
+            const key = (typeof exampleKeyFn === 'function') ? exampleKeyFn(ans) : (ans && ans.english);
+            ex = examples[key];
+          }
           renderers.renderExample(fb, ex);
         } catch (e) { logError(e, 'quiz.factories.onAnswered'); }
       }

--- a/js/ui/renderers.js
+++ b/js/ui/renderers.js
@@ -48,10 +48,10 @@
       // Clear any inline feedback content and remove previous overlays
       while (feedbackEl.firstChild) feedbackEl.removeChild(feedbackEl.firstChild);
       removeExistingExampleOverlay();
-      if (!exampleText) return;
 
       var correctHeading = (global.Utils && global.Utils.i18n && global.Utils.i18n.correctHeading) || 'Correct!';
       var durationMs = 2600;
+      var hasExample = !!exampleText;
 
       // Build a full-screen overlay to showcase the example prominently
       var overlay = document.createElement('div');
@@ -76,6 +76,7 @@
       var text = document.createElement('div');
       text.className = 'text';
       (function buildHighlightedText(){
+        if (!hasExample) { return; }
         try {
           var raw = String(exampleText);
           var parts = raw.split('→');
@@ -109,7 +110,7 @@
 
           if (tail) { text.appendChild(document.createTextNode(tail)); }
         } catch (_) {
-          text.textContent = String(exampleText);
+          try { text.textContent = String(exampleText); } catch (_) {}
         }
       })();
 


### PR DESCRIPTION
Always display the flag falling animation on correct answers, even when no example text is present.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dd8c987-6305-4cf3-b27d-a8b2f39e4a13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1dd8c987-6305-4cf3-b27d-a8b2f39e4a13">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

