### PR TITLE
Fix missing falling flag animation in color quiz

### DIFF
--- a/js/builders/index.js
+++ b/js/builders/index.js
@@ -124,7 +124,15 @@
             },
             renderButtonContent: function(choice) { return choice.phonetic; },
             ariaLabelForChoice: function(choice) { return Utils.i18n.answerPrefix + choice.phonetic; },
-            isCorrect: function(choice, answer) { return choice.phonetic === answer.phonetic; }
+            isCorrect: function(choice, answer) { return choice.phonetic === answer.phonetic; },
+            onAnswered: function(ctx) {
+              if (!ctx || !ctx.correct) return;
+              try {
+                var ans = ctx.answer || {};
+                var text = (ans.english || '') + ' → ' + (ans.thai || '') + (ans.phonetic ? (' — ' + ans.phonetic) : '');
+                Utils.renderExample(document.getElementById('feedback'), text);
+              } catch (e) { Utils.logError && Utils.logError(e, 'colors.onAnswered'); }
+            }
           });
         };
       });


### PR DESCRIPTION
Enable the falling flag success animation for the color quiz on correct answers.

---
<a href="https://cursor.com/background-agent?bcId=bc-21dcf2b5-71c1-4df3-a55c-6ac530c6b1e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21dcf2b5-71c1-4df3-a55c-6ac530c6b1e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

