### PR TITLE
Implement thai consonant cluster quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Hosted with GitHub Pages: [https://jdelaire.github.io/learn-thai-quiz](https://j
  - **Countries**: Country names with Thai script, phonetics, and flag emoji hints; example sentences on correct answers
  - **Vowels That Change Form**: Thai vowels that change their writing form between consonants; English/Thai/phonetics with examples and a quick reference table.
  - **Consonants in Final Position (Individually)**: Thai consonants as final sounds with examples; maps to collapsed finals like k/t/p and nasals m/n/ŋ.
+ - **Consonant Clusters**: True vs fake clusters with Thai examples and phonetics
 
 ### Quick start (local)
 

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -1,5 +1,6 @@
 {
   "entries": [
+    { "id": "consonant-clusters", "date": "2025-09-19T10:00:00Z" },
     { "id": "final-consonants", "date": "2025-09-12T10:00:00Z" },
     { "id": "vowel-changes", "date": "2025-09-08T10:00:00Z" },
     { "id": "countries", "date": "2025-08-31T10:00:00Z" },

--- a/data/consonant-clusters.json
+++ b/data/consonant-clusters.json
@@ -1,0 +1,22 @@
+[
+  { "id": "kr-gam", "type": "true", "cluster": "กร", "sounds": "gr", "thai": "กรรม", "english": "karma, deed", "phonetic": "gam", "emoji": "⚖️" },
+  { "id": "gl-glaang", "type": "true", "cluster": "กล", "sounds": "gl", "thai": "กลาง", "english": "middle", "phonetic": "glaaŋ", "emoji": "📍" },
+  { "id": "gw-gwaa", "type": "true", "cluster": "กว", "sounds": "gw", "thai": "กว่า", "english": "than", "phonetic": "gwàa", "emoji": "➡️" },
+  { "id": "pr-prathet", "type": "true", "cluster": "ปร", "sounds": "pr", "thai": "ประเทศ", "english": "country", "phonetic": "bprà-thêet", "emoji": "🌏" },
+  { "id": "pl-bplaa", "type": "true", "cluster": "ปล", "sounds": "pl", "thai": "ปลา", "english": "fish", "phonetic": "bplaa", "emoji": "🐟" },
+  { "id": "dtr-dtamruat", "type": "true", "cluster": "ตร", "sounds": "dtr", "thai": "ตำรวจ", "english": "police", "phonetic": "dtam-rùat", "emoji": "👮" },
+  { "id": "khr-khrukhra", "type": "true", "cluster": "ขร", "sounds": "khr", "thai": "ขรุขระ", "english": "rough, uneven", "phonetic": "khrù-khrà", "emoji": "🪨" },
+  { "id": "khl-khluy", "type": "true", "cluster": "ขล", "sounds": "khl", "thai": "ขลุ่ย", "english": "flute", "phonetic": "khlùy", "emoji": "🎶" },
+  { "id": "khw-khwaa", "type": "true", "cluster": "ขว", "sounds": "khw", "thai": "ขวา", "english": "right side", "phonetic": "khwǎa", "emoji": "➡️" },
+  { "id": "khr-khruu", "type": "true", "cluster": "คร", "sounds": "khr", "thai": "ครู", "english": "teacher", "phonetic": "khruu", "emoji": "👩‍🏫" },
+  { "id": "khl-khluen", "type": "true", "cluster": "คล", "sounds": "khl", "thai": "คลื่น", "english": "wave", "phonetic": "khlʉ̂ʉn", "emoji": "🌊" },
+  { "id": "khw-khwaai", "type": "true", "cluster": "คว", "sounds": "khw", "thai": "ควาย", "english": "buffalo", "phonetic": "khwaai", "emoji": "🐃" },
+  { "id": "phr-phon", "type": "true", "cluster": "พร", "sounds": "phr", "thai": "พร", "english": "blessing", "phonetic": "phɔɔn", "emoji": "🙏" },
+  { "id": "phl-phalá", "type": "true", "cluster": "พล", "sounds": "phl", "thai": "พละ", "english": "strength, power", "phonetic": "phá-lá", "emoji": "💪" },
+
+  { "id": "jr-traffic", "type": "fake", "cluster": "จร", "sounds": "j", "thai": "จราจร", "english": "traffic", "phonetic": "jà-raa-jon", "emoji": "🚦" },
+  { "id": "sr-suang", "type": "fake", "cluster": "สร", "sounds": "s", "thai": "สรวง", "english": "heaven, divine realm", "phonetic": "sǔaŋ", "emoji": "✨" },
+  { "id": "sr-satthaa", "type": "fake", "cluster": "ศร", "sounds": "s", "thai": "ศรัทธา", "english": "faith", "phonetic": "sàt-thaa", "emoji": "🛐" },
+  { "id": "sr-sop", "type": "fake", "cluster": "ซร", "sounds": "s", "thai": "ซรบ", "english": "(rare) archaic reading", "phonetic": "sop", "emoji": "📜" },
+  { "id": "tr-song", "type": "fake", "cluster": "ทร", "sounds": "s", "thai": "ทรง", "english": "royal ‘to wear/hold’", "phonetic": "soŋ", "emoji": "👑" }
+]

--- a/data/quizzes.json
+++ b/data/quizzes.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "consonant-clusters",
+    "title": "Consonant Clusters 🔗",
+    "href": "quiz.html?quiz=consonant-clusters",
+    "description": "Thai consonant clusters: true vs fake clusters with examples and phonetics.",
+    "bullets": ["True (อักษรควบแท้) and Fake (อักษรควบไม่แท้)","R/L/W clusters","Silent second consonant (ทร → s)"],
+    "categories": ["Alphabet","Reading","Pronunciation"],
+    "bodyClass": "questions-quiz",
+    "proTip": "<strong>Clusters:</strong> True clusters pronounce both consonants (usually +ร/ล/ว). Fake clusters only pronounce the first (e.g., <strong>ทร</strong> → <em>s</em>)."
+  },
+  {
     "id": "final-consonants",
     "title": "Consonants in Final Position 📜",
     "href": "quiz.html?quiz=final-consonants",

--- a/js/builders/index.js
+++ b/js/builders/index.js
@@ -45,6 +45,18 @@
   }
 
   const QuizBuilders = {
+    'consonant-clusters': makeStandardQuizBuilder('data/consonant-clusters.json', function(results) {
+      const data = results[0] || [];
+      return {
+        data: data,
+        answerKey: 'sounds',
+        buildSymbol: function(a){
+          var prefix = a && a.type === 'fake' ? 'Fake cluster' : 'True cluster';
+          var english = ((prefix + ': ' + (a.cluster || '') + ' → ' + (a.sounds || '')) + (a.english ? (' — ' + a.english) : ''));
+          return { english: english, thai: (a.thai || ''), emoji: (a.emoji || '') };
+        }
+      };
+    }),
     'final-consonants': function() {
       return Utils.fetchJSONCached('data/final-consonants.json').then(function(data){
         return function init(){


### PR DESCRIPTION
Implement the 'Thai Consonant Clusters Cheat Sheet' quiz to introduce true and fake Thai consonant clusters.

---
<a href="https://cursor.com/background-agent?bcId=bc-26bad85b-7dc3-41af-91ee-7d2acb6ee547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26bad85b-7dc3-41af-91ee-7d2acb6ee547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

