### PR TITLE
Add quest navigation scaffold to home page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -669,9 +669,10 @@ body.home .quest-card {
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.06);
   transition: transform 0.2s ease;
   cursor: default;
-  min-width: 320px;
+  width: 100%;
   max-width: 640px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 body.home .quest-card:hover {
@@ -724,41 +725,16 @@ body.home .quest-progress {
   font-weight: 700;
 }
 
-body.home .quest-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 1em;
-  margin: 1.4em 0 1.6em;
-}
-
-body.home .quest-step {
-  background: rgba(0, 0, 0, 0.03);
-  border-radius: 16px;
-  padding: 0.9em 1.1em;
-}
-
 body.home .quest-card.preview {
   border-style: dashed;
   position: relative;
 }
 
-body.home .quest-step.locked {
-  opacity: 0.5;
-  background: rgba(0, 0, 0, 0.05);
-}
-
-body.home .quest-card.preview .quest-steps {
-  margin-top: 1.2em;
-}
-
-body.home .quest-card.preview .quest-step {
-  border-style: dashed;
-  border-radius: 16px;
-  opacity: 0.85;
-}
-
-body.home .quest-card.preview .quest-step-status {
-  opacity: 0.7;
+body.home .quest-steps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6em;
+  margin: 1.4em 0 1.6em;
 }
 
 body.home .quest-lock-overlay {
@@ -782,32 +758,17 @@ body.home .quest-lock-message {
   color: var(--color-text);
 }
 
-body.home .quest-step-header {
-  display: flex;
-  align-items: center;
-  gap: 0.6em;
-  font-weight: 700;
+body.home .quest-preview-topics {
+  margin: 1.2em 0 0;
+  padding-left: 1.4em;
+  list-style: disc;
+  font-weight: 600;
+  opacity: 0.85;
+  text-align: left;
 }
 
-body.home .quest-step-progress {
-  margin-left: auto;
-  font-size: 0.9em;
-  opacity: 0.65;
-}
-
-body.home .quest-step-status {
-  font-size: 1.2em;
-}
-
-body.home .quest-step-status.incomplete {
-  opacity: 0.6;
-}
-
-body.home .quest-step-quizzes {
-  margin-top: 0.6em;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6em;
+body.home .quest-preview-topics li {
+  margin: 0.3em 0;
 }
 
 body.home .quest-quiz {

--- a/css/styles.css
+++ b/css/styles.css
@@ -622,7 +622,7 @@ body.home .view-toggle {
   justify-content: center;
   gap: 0.75em;
   flex-wrap: wrap;
-  margin: 1.5em auto 1em;
+  margin: 1em auto 1em;
 }
 
 body.home .view-chip {
@@ -685,6 +685,22 @@ body.home .quest-header {
   margin-bottom: 0.8em;
 }
 
+body.home .quest-collapse-btn {
+  margin-top: 0.6em;
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: var(--color-accent);
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0;
+}
+
+body.home .quest-collapse-btn:hover,
+body.home .quest-collapse-btn:focus-visible {
+  text-decoration: underline;
+}
+
 body.home .quest-title {
   font-size: 1.8em;
   font-weight: 800;
@@ -721,6 +737,50 @@ body.home .quest-step {
   padding: 0.9em 1.1em;
 }
 
+body.home .quest-card.preview {
+  border-style: dashed;
+  position: relative;
+}
+
+body.home .quest-step.locked {
+  opacity: 0.5;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+body.home .quest-card.preview .quest-steps {
+  margin-top: 1.2em;
+}
+
+body.home .quest-card.preview .quest-step {
+  border-style: dashed;
+  opacity: 0.85;
+}
+
+body.home .quest-card.preview .quest-step-status {
+  opacity: 0.7;
+}
+
+body.home .quest-lock-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5em;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 16px;
+  text-align: center;
+}
+
+body.home .quest-lock-message {
+  font-weight: 700;
+  font-size: 1.05em;
+  color: var(--color-text);
+}
+
 body.home .quest-step-header {
   display: flex;
   align-items: center;
@@ -751,8 +811,8 @@ body.home .quest-step-quizzes {
 
 body.home .quest-quiz {
   display: inline-flex;
-  align-items: center;
-  gap: 0.35em;
+  align-items: flex-start;
+  gap: 0.6em;
   padding: 0.45em 0.9em;
   border-radius: 999px;
   border: 1px solid rgba(0, 0, 0, 0.12);
@@ -763,6 +823,29 @@ body.home .quest-quiz {
   font-size: 0.95em;
 }
 
+body.home .quest-quiz-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+body.home .quest-quiz-title {
+  font-weight: 600;
+}
+
+body.home .quest-quiz-meta {
+  font-size: 0.85em;
+  opacity: 0.75;
+  font-weight: 500;
+}
+
+body.home .quest-quiz.locked {
+  background: rgba(0, 0, 0, 0.07);
+  border-color: rgba(0, 0, 0, 0.12);
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 body.home .quest-quiz.complete {
   background: rgba(43, 160, 91, 0.18);
   border-color: rgba(43, 160, 91, 0.4);
@@ -771,10 +854,6 @@ body.home .quest-quiz.complete {
 body.home .quest-quiz:focus-visible {
   outline: 3px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-body.home .quest-quiz-status {
-  font-size: 1.05em;
 }
 
 body.home .quest-actions {
@@ -968,7 +1047,7 @@ body.home .socials a.chip {
   display: block;
   width: 100%;
   max-width: 760px;
-  margin: 0 auto 0.8em;
+  margin: 0 auto 0;
   text-align: left;
   background: var(--color-bg);
   border: 1px solid rgba(0, 0, 0, 0.08);
@@ -1168,7 +1247,7 @@ body.home .socials a.chip {
 @media (max-width: 560px) {
   .player-card { 
     padding: 0.9em 1em; 
-    margin: 0 auto 0.8em;
+    margin: 0 auto 0;
     width: 100%;
     box-sizing: border-box;
     position: relative;
@@ -1574,7 +1653,7 @@ body.questions-quiz .correct-line {
   
   .player-card { 
     padding: 0.8em 0.8em; 
-    margin: 0 auto 0.8em;
+    margin: 0 auto 0;
     width: 100%;
   }
   .player-metrics { 

--- a/css/styles.css
+++ b/css/styles.css
@@ -733,7 +733,7 @@ body.home .quest-steps {
 
 body.home .quest-step {
   background: rgba(0, 0, 0, 0.03);
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 0.9em 1.1em;
 }
 
@@ -753,6 +753,7 @@ body.home .quest-card.preview .quest-steps {
 
 body.home .quest-card.preview .quest-step {
   border-style: dashed;
+  border-radius: 16px;
   opacity: 0.85;
 }
 
@@ -814,7 +815,7 @@ body.home .quest-quiz {
   align-items: flex-start;
   gap: 0.6em;
   padding: 0.45em 0.9em;
-  border-radius: 999px;
+  border-radius: 16px;
   border: 1px solid rgba(0, 0, 0, 0.12);
   background: rgba(255, 255, 255, 0.9);
   text-decoration: none;

--- a/css/styles.css
+++ b/css/styles.css
@@ -617,6 +617,186 @@ body.home .quiz-container {
   margin-bottom: 2em;
 }
 
+body.home .view-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 0.75em;
+  flex-wrap: wrap;
+  margin: 1.5em auto 1em;
+}
+
+body.home .view-chip {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-radius: 999px;
+  padding: 0.6em 1.4em;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+body.home .view-chip:hover {
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
+}
+
+body.home .view-chip.active {
+  background: var(--color-accent);
+  color: var(--color-bg);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.18);
+}
+
+body.home .view-chip:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+body.home.quest-mode .filters {
+  display: none;
+}
+
+body.home.quest-mode .quiz-container {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1.5em;
+}
+
+body.home .quest-card {
+  background: var(--color-bg);
+  border-radius: 16px;
+  padding: 1.8em;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s ease;
+  cursor: default;
+  min-width: 320px;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+body.home .quest-card:hover {
+  transform: translateY(-4px);
+}
+
+body.home .quest-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4em;
+  margin-bottom: 0.8em;
+}
+
+body.home .quest-title {
+  font-size: 1.8em;
+  font-weight: 800;
+  color: var(--color-text);
+}
+
+body.home .quest-tagline {
+  font-weight: 600;
+  opacity: 0.75;
+  font-size: 1.05em;
+}
+
+body.home .quest-goal {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.9;
+}
+
+body.home .quest-progress {
+  margin-top: 1em;
+  font-weight: 700;
+}
+
+body.home .quest-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin: 1.4em 0 1.6em;
+}
+
+body.home .quest-step {
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 12px;
+  padding: 0.9em 1.1em;
+}
+
+body.home .quest-step-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  font-weight: 700;
+}
+
+body.home .quest-step-progress {
+  margin-left: auto;
+  font-size: 0.9em;
+  opacity: 0.65;
+}
+
+body.home .quest-step-status {
+  font-size: 1.2em;
+}
+
+body.home .quest-step-status.incomplete {
+  opacity: 0.6;
+}
+
+body.home .quest-step-quizzes {
+  margin-top: 0.6em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6em;
+}
+
+body.home .quest-quiz {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.45em 0.9em;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 0.95em;
+}
+
+body.home .quest-quiz.complete {
+  background: rgba(43, 160, 91, 0.18);
+  border-color: rgba(43, 160, 91, 0.4);
+}
+
+body.home .quest-quiz:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+body.home .quest-quiz-status {
+  font-size: 1.05em;
+}
+
+body.home .quest-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+body.home .quest-action-btn {
+  text-decoration: none;
+}
+
+body.home .quest-finished {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.6em 1.2em;
+  border-radius: 999px;
+  background: rgba(43, 160, 91, 0.18);
+  border: 1px solid rgba(43, 160, 91, 0.4);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
 body.home .quiz-card {
   background: var(--color-bg);
   backdrop-filter: none;

--- a/data/prepositions-examples.json
+++ b/data/prepositions-examples.json
@@ -11,5 +11,7 @@
     "inside": "khon yùu khâaŋ-nai hɔ̂ŋ → Someone is inside the room",
     "outside": "mâa yùu khâaŋ-nɔ̂ɔk bâan → The dog is outside the house",
     "at / to (a place)": "chǎn jà pai thîi ráan-kǎai → I will go to the store",
-    "there is / are": "mii náam-plào nàk-tò → There’s water on the table"
-  }
+    "there is / are": "mii náam-plào nàk-tò → There’s water on the table",
+    "before": "rao kin khâao gɔ̀ɔn pai tham-ngaan → We eat before going to work",
+    "after": "khǎo phák pòn lǎŋ kin khâao → They rest after eating"
+}

--- a/data/prepositions.json
+++ b/data/prepositions.json
@@ -76,5 +76,17 @@
     "thai": "มี",
     "phonetic": "mii",
     "emoji": "✅"
+  },
+  {
+    "english": "before",
+    "thai": "ก่อน",
+    "phonetic": "gɔ̀ɔn",
+    "emoji": "⏮️"
+  },
+  {
+    "english": "after",
+    "thai": "หลัง",
+    "phonetic": "lǎŋ",
+    "emoji": "⏭️"
   }
 ]

--- a/data/quests.json
+++ b/data/quests.json
@@ -1,36 +1,36 @@
 [
   {
     "id": "quest-survival-basics",
-    "title": "Quest 1: Survival Basics",
+    "title": "Quest 1: Survival Starter",
     "emoji": "🟢",
     "tagline": "Beginner Conversation",
     "goal": "Hold a very simple intro conversation, ask the time/day, count things.",
     "steps": [
       {
-        "title": "Numbers, time, days, months, seasons",
-        "quizIds": ["numbers", "time", "days", "months"]
-      },
-      {
-        "title": "Greetings & polite particles",
+        "title": "Greetings",
         "quizIds": ["greetings"]
       },
       {
-        "title": "Basic classifiers (people, bottles, animals...)",
-        "quizIds": ["classifiers"]
+        "title": "Numbers",
+        "quizIds": ["numbers"]
       },
       {
-        "title": "Essential adjectives (big/small, hot/cold)",
+        "title": "Colors",
+        "quizIds": ["colors"]
+      },
+      {
+        "title": "Family",
+        "quizIds": ["family"]
+      },
+      {
+        "title": "Adjectives",
         "quizIds": ["adjectives"]
-      },
-      {
-        "title": "Yes/no, question words",
-        "quizIds": ["questions"]
       }
     ]
   },
   {
     "id": "quest-daily-life",
-    "title": "Quest 2: Daily Life",
+    "title": "Quest 2: Daily Life Explorer",
     "emoji": "🟡",
     "tagline": "Elementary Conversation",
     "goal": "Order food, talk about daily routine, make simple plans.",
@@ -38,24 +38,124 @@
     "requiresQuestId": "quest-survival-basics",
     "steps": [
       {
-        "title": "Food & drinks vocabulary",
+        "title": "Days",
+        "quizIds": ["days"]
+      },
+      {
+        "title": "Months",
+        "quizIds": ["months"]
+      },
+      {
+        "title": "Time",
+        "quizIds": ["time"]
+      },
+      {
+        "title": "Prepositions",
+        "quizIds": ["prepositions"]
+      },
+      {
+        "title": "Countries",
+        "quizIds": ["countries"]
+      }
+    ]
+  },
+  {
+    "id": "quest-script-foundations",
+    "title": "Quest 3: Script Foundations",
+    "emoji": "🔵",
+    "tagline": "RW Level 1",
+    "goal": "Recognize and write the 44 consonants, read simple syllables.",
+    "preview": true,
+    "requiresQuestId": "quest-daily-life",
+    "steps": [
+      {
+        "title": "Consonants",
+        "quizIds": ["consonants"]
+      },
+      {
+        "title": "Vowels",
+        "quizIds": ["vowels"]
+      },
+      {
+        "title": "Final consonants",
+        "quizIds": ["final-consonants"]
+      }
+    ]
+  },
+  {
+    "id": "quest-word-builder",
+    "title": "Quest 4: Word Builder",
+    "emoji": "🟣",
+    "tagline": "Reading boosts",
+    "goal": "Build confidence reading multi-letter syllables and special vowel forms.",
+    "preview": true,
+    "requiresQuestId": "quest-script-foundations",
+    "steps": [
+      {
+        "title": "Vowel changes",
+        "quizIds": ["vowel-changes"]
+      },
+      {
+        "title": "Consonant clusters",
+        "quizIds": ["consonant-clusters"]
+      },
+      {
+        "title": "Sara ใ- words",
+        "quizIds": ["sara-ai-mai-muan"]
+      }
+    ]
+  },
+  {
+    "id": "quest-everyday-conversation",
+    "title": "Quest 5: Everyday Conversation",
+    "emoji": "🔴",
+    "tagline": "Make plans, talk daily life",
+    "goal": "Carry on everyday conversations about food, home, and routines.",
+    "preview": true,
+    "requiresQuestId": "quest-word-builder",
+    "steps": [
+      {
+        "title": "Questions",
+        "quizIds": ["questions"]
+      },
+      {
+        "title": "Common verbs",
+        "quizIds": ["verbs"]
+      },
+      {
+        "title": "Foods",
         "quizIds": ["foods"]
       },
       {
-        "title": "Family & people",
-        "quizIds": ["family", "jobs"]
+        "title": "Rooms",
+        "quizIds": ["rooms"]
       },
       {
-        "title": "Places in town",
-        "quizIds": ["rooms", "prepositions"]
+        "title": "Jobs",
+        "quizIds": ["jobs"]
+      }
+    ]
+  },
+  {
+    "id": "quest-grammar-tone",
+    "title": "Quest 6: Grammar & Tone Mastery",
+    "emoji": "⚫",
+    "tagline": "Pronounce with confidence",
+    "goal": "Use classifiers correctly, master tones, and talk about time with accuracy.",
+    "preview": true,
+    "requiresQuestId": "quest-everyday-conversation",
+    "steps": [
+      {
+        "title": "Classifiers",
+        "quizIds": ["classifiers"]
       },
       {
-        "title": "Tense markers (yesterday, already, not yet)",
-        "quizIds": ["tenses", "time"]
+        "title": "Tone rules",
+        "quizIds": ["tones"]
       },
       {
-        "title": "Using \"before/after\" structures",
-        "quizIds": ["verbs", "prepositions"]
+        "title": "Tense markers",
+        "quizIds": ["tenses"]
       }
     ]
   }

--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "quest-survival-basics",
+    "title": "Quest 1: Survival Basics",
+    "emoji": "🟢",
+    "tagline": "Beginner Conversation",
+    "goal": "Hold a very simple intro conversation, ask the time/day, count things.",
+    "steps": [
+      {
+        "title": "Numbers, time, days, months, seasons",
+        "quizIds": ["numbers", "time", "days", "months"]
+      },
+      {
+        "title": "Greetings & polite particles",
+        "quizIds": ["greetings"]
+      },
+      {
+        "title": "Basic classifiers (people, bottles, animals...)",
+        "quizIds": ["classifiers"]
+      },
+      {
+        "title": "Essential adjectives (big/small, hot/cold)",
+        "quizIds": ["adjectives"]
+      },
+      {
+        "title": "Yes/no, question words",
+        "quizIds": ["questions"]
+      }
+    ]
+  }
+]

--- a/data/quests.json
+++ b/data/quests.json
@@ -27,5 +27,36 @@
         "quizIds": ["questions"]
       }
     ]
+  },
+  {
+    "id": "quest-daily-life",
+    "title": "Quest 2: Daily Life",
+    "emoji": "🟡",
+    "tagline": "Elementary Conversation",
+    "goal": "Order food, talk about daily routine, make simple plans.",
+    "preview": true,
+    "requiresQuestId": "quest-survival-basics",
+    "steps": [
+      {
+        "title": "Food & drinks vocabulary",
+        "quizIds": ["foods"]
+      },
+      {
+        "title": "Family & people",
+        "quizIds": ["family", "jobs"]
+      },
+      {
+        "title": "Places in town",
+        "quizIds": ["rooms", "prepositions"]
+      },
+      {
+        "title": "Tense markers (yesterday, already, not yet)",
+        "quizIds": ["tenses", "time"]
+      },
+      {
+        "title": "Using \"before/after\" structures",
+        "quizIds": ["verbs", "prepositions"]
+      }
+    ]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -98,6 +98,11 @@
     </div>
   </header>
   
+  <div id="view-toggle" class="view-toggle" role="group" aria-label="Navigation mode">
+    <button type="button" class="view-chip active" data-mode="browse">Browse all quizzes</button>
+    <button type="button" class="view-chip" data-mode="quest">Quest mode</button>
+  </div>
+
   <div id="filters" class="filters" aria-label="Quiz filters">
     <input id="search-input" type="search" placeholder="Search quizzes (e.g., vowels, time, colors)" autocomplete="off" />
     <div id="category-filters" class="chip-group" role="group" aria-label="Categories"></div>

--- a/js/smoke.js
+++ b/js/smoke.js
@@ -853,6 +853,9 @@
       window.StorageService && window.StorageService.setJSON(pkey, { questionsAnswered: 100, correctAnswers: 100 });
       const akey = 'thaiQuest.lastAttempt.' + quizId;
       window.StorageService && window.StorageService.setNumber(akey, Date.now());
+      // Force Browse All view so the quiz cards render with star ratings
+      const viewKey = 'thaiQuest.home.viewMode';
+      window.StorageService && window.StorageService.setItem(viewKey, 'browse');
 
       const nav = await withTimeout(navigateFrame(iframe, serverRoot + '/index.html'), 6000, 'Home did not load');
       if (!nav.ok) return { name: name, ok: false, details: String(nav.error) };


### PR DESCRIPTION
## Summary
- add a navigation mode toggle on the home page and hide filters in quest mode
- create a quest card layout and supporting logic that groups quizzes into a first Survival Basics quest
- load quest metadata from a new data/quests.json file and compute per-quest progress with continue buttons

## Testing
- python -m json.tool data/quests.json

------
https://chatgpt.com/codex/tasks/task_e_68d63f5150e483248ee896c39ef8d70e